### PR TITLE
type mismatch warning

### DIFF
--- a/src/lib/libssl/src/crypto/gost/gostr341001_pmeth.c
+++ b/src/lib/libssl/src/crypto/gost/gostr341001_pmeth.c
@@ -594,7 +594,7 @@ pkey_gost01_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
 
 	case EVP_PKEY_CTRL_SET_IV:
 	    {
-		char *ukm = malloc(p1);
+		unsigned char *ukm = malloc(p1);
 
 		if (ukm == NULL) {
 			GOSTerr(GOST_F_PKEY_GOST01_CTRL,

--- a/src/lib/libssl/src/ssl/s3_srvr.c
+++ b/src/lib/libssl/src/ssl/s3_srvr.c
@@ -1911,7 +1911,7 @@ ssl3_get_client_key_exchange(SSL *s)
 			 * section 7.4.7.1).
 			 */
 			i = SSL_MAX_MASTER_KEY_LENGTH;
-			p = fakekey;
+			p = (unsigned char *)fakekey;
 		}
 
 		s->session->master_key_length =

--- a/src/lib/libtls/tls_verify.c
+++ b/src/lib/libtls/tls_verify.c
@@ -122,7 +122,7 @@ tls_check_subject_altname(struct tls *ctx, X509 *cert, const char *host)
 				data = ASN1_STRING_data(altname->d.dNSName);
 				len = ASN1_STRING_length(altname->d.dNSName);
 
-				if (len < 0 || len != strlen(data)) {
+				if (len < 0 || len != strlen((char *)data)) {
 					tls_set_error(ctx,
 					    "error verifying host '%s': "
 					    "NUL byte in subjectAltName, "
@@ -132,7 +132,7 @@ tls_check_subject_altname(struct tls *ctx, X509 *cert, const char *host)
 					break;
 				}
 
-				if (tls_match_hostname(data, host) == 0) {
+				if (tls_match_hostname((char *)data, host) == 0) {
 					rv = 0;
 					break;
 				}

--- a/src/regress/lib/libcrypto/aead/aeadtest.c
+++ b/src/regress/lib/libcrypto/aead/aeadtest.c
@@ -255,7 +255,7 @@ main(int argc, char **argv)
 			if (!any_values_set)
 				continue;
 
-			switch (aead_from_name(&aead, bufs[AEAD])) {
+			switch (aead_from_name(&aead, (char *)bufs[AEAD])) {
 			case 0:
 				fprintf(stderr, "Skipping test...\n");
 				continue;
@@ -318,7 +318,7 @@ main(int argc, char **argv)
 		}
 
 		if (j == AEAD) {
-			*buf_len = strlcpy(buf, line + i, BUF_MAX);
+			*buf_len = strlcpy((char *)buf, line + i, BUF_MAX);
 			for (j = 0; j < BUF_MAX; j++) {
 				if (buf[j] == '\n')
 					buf[j] = '\0';

--- a/src/regress/lib/libssl/asn1/asn1test.c
+++ b/src/regress/lib/libssl/asn1/asn1test.c
@@ -255,7 +255,7 @@ session_cmp(SSL_SESSION *s1, SSL_SESSION *s2)
 		return (1);
 	}
 
-	if (session_strcmp(s1->tlsext_hostname, s2->tlsext_hostname,
+	if (session_strcmp((unsigned char *)s1->tlsext_hostname, (unsigned char *)s2->tlsext_hostname,
 	    (s1->tlsext_hostname ? strlen(s1->tlsext_hostname) : 0)) != 0) {
 		fprintf(stderr, "sid_ctx differs\n");
 		return (1);


### PR DESCRIPTION
found type mismatch.
HP C/aC++ compiler detects these type mismatch warning.