### PR TITLE
modify BSIZE to BUFLEN in apps.c and ca.c

### DIFF
--- a/src/usr.bin/openssl/apps.c
+++ b/src/usr.bin/openssl/apps.c
@@ -1384,7 +1384,7 @@ static IMPLEMENT_LHASH_COMP_FN(index_serial, OPENSSL_CSTRING)
 static IMPLEMENT_LHASH_HASH_FN(index_name, OPENSSL_CSTRING)
 static IMPLEMENT_LHASH_COMP_FN(index_name, OPENSSL_CSTRING)
 
-#define BSIZE 256
+#define BUFLEN 256
 
 BIGNUM *
 load_serial(char *serialfile, int create, ASN1_INTEGER **retai)
@@ -1442,7 +1442,7 @@ int
 save_serial(char *serialfile, char *suffix, BIGNUM *serial,
     ASN1_INTEGER **retai)
 {
-	char buf[1][BSIZE];
+	char buf[1][BUFLEN];
 	BIO *out = NULL;
 	int ret = 0, n;
 	ASN1_INTEGER *ai = NULL;
@@ -1452,12 +1452,12 @@ save_serial(char *serialfile, char *suffix, BIGNUM *serial,
 		j = strlen(serialfile);
 	else
 		j = strlen(serialfile) + strlen(suffix) + 1;
-	if (j >= BSIZE) {
+	if (j >= BUFLEN) {
 		BIO_printf(bio_err, "file name too long\n");
 		goto err;
 	}
 	if (suffix == NULL)
-		n = strlcpy(buf[0], serialfile, BSIZE);
+		n = strlcpy(buf[0], serialfile, BUFLEN);
 	else
 		n = snprintf(buf[0], sizeof buf[0], "%s.%s",
 		    serialfile, suffix);
@@ -1498,14 +1498,14 @@ err:
 int
 rotate_serial(char *serialfile, char *new_suffix, char *old_suffix)
 {
-	char buf[5][BSIZE];
+	char buf[5][BUFLEN];
 	int i, j;
 
 	i = strlen(serialfile) + strlen(old_suffix);
 	j = strlen(serialfile) + strlen(new_suffix);
 	if (i > j)
 		j = i;
-	if (j + 1 >= BSIZE) {
+	if (j + 1 >= BUFLEN) {
 		BIO_printf(bio_err, "file name too long\n");
 		goto err;
 	}
@@ -1570,7 +1570,7 @@ load_index(char *dbfile, DB_ATTR *db_attr)
 	TXT_DB *tmpdb = NULL;
 	BIO *in = BIO_new(BIO_s_file());
 	CONF *dbattr_conf = NULL;
-	char buf[1][BSIZE];
+	char buf[1][BUFLEN];
 	long errorline = -1;
 
 	if (in == NULL) {
@@ -1650,7 +1650,7 @@ index_index(CA_DB *db)
 int
 save_index(const char *dbfile, const char *suffix, CA_DB *db)
 {
-	char buf[3][BSIZE];
+	char buf[3][BUFLEN];
 	BIO *out = BIO_new(BIO_s_file());
 	int j;
 
@@ -1659,7 +1659,7 @@ save_index(const char *dbfile, const char *suffix, CA_DB *db)
 		goto err;
 	}
 	j = strlen(dbfile) + strlen(suffix);
-	if (j + 6 >= BSIZE) {
+	if (j + 6 >= BUFLEN) {
 		BIO_printf(bio_err, "file name too long\n");
 		goto err;
 	}
@@ -1700,14 +1700,14 @@ err:
 int
 rotate_index(const char *dbfile, const char *new_suffix, const char *old_suffix)
 {
-	char buf[5][BSIZE];
+	char buf[5][BUFLEN];
 	int i, j;
 
 	i = strlen(dbfile) + strlen(old_suffix);
 	j = strlen(dbfile) + strlen(new_suffix);
 	if (i > j)
 		j = i;
-	if (j + 6 >= BSIZE) {
+	if (j + 6 >= BUFLEN) {
 		BIO_printf(bio_err, "file name too long\n");
 		goto err;
 	}

--- a/src/usr.bin/openssl/ca.c
+++ b/src/usr.bin/openssl/ca.c
@@ -291,8 +291,8 @@ ca_main(int argc, char **argv)
 	STACK_OF(CONF_VALUE) * attribs = NULL;
 	STACK_OF(X509) * cert_sk = NULL;
 	STACK_OF(OPENSSL_STRING) * sigopts = NULL;
-#define BSIZE 256
-	char buf[3][BSIZE];
+#define BUFLEN 256
+	char buf[3][BUFLEN];
 #ifndef OPENSSL_NO_ENGINE
 	char *engine = NULL;
 #endif


### PR DESCRIPTION
compiler detects redefinition of BSIZE since hpux has BSIZE in its header file.
comment in https://github.com/libressl-portable/portable/pull/46