### PR TITLE
Adding tls_quit() function for freeing memory as much as possible

### DIFF
--- a/src/lib/libtls/tls.c
+++ b/src/lib/libtls/tls.c
@@ -26,6 +26,9 @@
 #include <openssl/evp.h>
 #include <openssl/pem.h>
 #include <openssl/x509.h>
+#include <openssl/conf.h>
+#include <openssl/err.h>
+#include <openssl/engine.h>
 
 #include <tls.h>
 #include "tls_internal.h"
@@ -49,6 +52,19 @@ tls_init(void)
 	tls_initialised = 1;
 
 	return (0);
+}
+
+void
+tls_quit(void)
+{
+	CONF_modules_free();
+	ERR_remove_state(0);
+	ENGINE_cleanup();
+	CONF_modules_unload(1);
+	ERR_free_strings();
+	EVP_cleanup();
+	CRYPTO_cleanup_all_ex_data();
+	sk_SSL_COMP_free(SSL_COMP_get_compression_methods());
 }
 
 const char *

--- a/src/lib/libtls/tls.h
+++ b/src/lib/libtls/tls.h
@@ -34,6 +34,7 @@ struct tls;
 struct tls_config;
 
 int tls_init(void);
+void tls_quit(void);
 
 const char *tls_error(struct tls *ctx);
 


### PR DESCRIPTION
I noticed there were memory leaks while using libtls. It already existed with the previous implementation of openSSL.

Though I didn't managed to remove every memory leak, I guess this could be a lead to fixing them once and for all.

Given the following test code:

```c
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <stdint.h>
#include <tls.h>

int main(int argc, char** argv) {
    char buf[8192];
    tls_init();
    
    struct tls_config* tlsconf = tls_config_new();
    printf("tls_config_set_ciphers(): %d\n", tls_config_set_ciphers(tlsconf, "DEFAULT"));
    printf("tls_config_set_ca_file(): %d\n", tls_config_set_ca_file(tlsconf, "./rootCA.pem"));
    tls_config_set_protocols(tlsconf, TLS_PROTOCOL_TLSv1_0|TLS_PROTOCOL_TLSv1_1|TLS_PROTOCOL_TLSv1_2);


    tls_config_insecure_noverifyhost(tlsconf);
    tls_config_insecure_noverifycert(tlsconf);

    struct tls* tlsclient = tls_client();
    tls_configure(tlsclient, tlsconf);

    printf("Status: %d\n", tls_connect(tlsclient, "google.com", "443")); 

    size_t outlen;
    char req[] = "GET / HTTP/1.1\r\n"
    "Host: google.com\r\n"
    "Connection: close\r\n\r\n";
    tls_write(tlsclient, req, sizeof(req), &outlen);
    
    printf("Written %d bytes.\n", outlen);
    
    int ret = tls_read(tlsclient, buf, sizeof(buf)-1, &outlen);
    while(ret >= 0) {
        buf[outlen] = '\0';
        ret = tls_read(tlsclient, buf, sizeof(buf)-1, &outlen);
    }

    tls_close(tlsclient);
    tls_free(tlsclient);
    tls_config_free(tlsconf);
    //tls_quit();

    return EXIT_SUCCESS;
}
```

Here is the valgrind output without tls_quit():

```
==8047== HEAP SUMMARY:
==8047==     in use at exit: 82,234 bytes in 2,657 blocks
==8047==   total heap usage: 4,332 allocs, 1,675 frees, 281,857 bytes allocated
```

Here is the valgrind output with tls_quit():

```
==8070== HEAP SUMMARY:
==8070==     in use at exit: 114 bytes in 2 blocks
==8070==   total heap usage: 4,331 allocs, 4,329 frees, 281,865 bytes allocated
```

After digging into Google, I cannot do better at the moment. Can you tell me guys what do you think about my initiative?