### PR TITLE
tls_close: nonblock-friendly bidirectional shutdown

### DIFF
--- a/src/lib/libtls/tls_init.3
+++ b/src/lib/libtls/tls_init.3
@@ -391,9 +391,9 @@ will return 0 on success and -1 on error.
 Functions that return a pointer will return NULL on error.
 .Pp
 The
-.Fn tls_read
-and
-.Fn tls_write
+.Fn tls_read ,
+.Fn tls_write , and
+.Fn tls_close
 functions and the
 .Fn tls_connect
 family of functions have two special return values.
@@ -406,7 +406,9 @@ A write operation is necessary to continue.
 .El
 .Pp
 The caller should call the appropriate function, or in the case of
-.Fn tls_connect ,
+.Fn tls_connect
+and
+.Fn tls_close ,
 repeat the call.
 .Sh ERRORS
 The


### PR DESCRIPTION
I noticed that tls_read, tls_write and tls_connect were non-blocking friendly, but tls_close was not yet

This implementation appears to be correct based on my reading of SSL_shutdown(3) (though I'm not familiar with OpenSSL's warts, so I don't know that it's not actually more complicated than this), specifically:

* return of 0 means our end of the shutdown is successfully completed, but we should call SSL_shutdown again to wait for the remote end's to complete
* return of 1 means bidirectional shutdown has completed successfully
* return of -1 means either an error occurred, or that the request would block; check the result of SSL_get_error

I guess one could wrap the SSL_shutdown calls in a loop instead, like
`do { ssl_ret = SSL_shutdown(...); } while (ssl_ret == 0);`
but I don't think that's correct.  To my reading, SSL_shutdown will only return 0 once, and the next call will either complete the shutdown or fail.