### PR TITLE
Add the ability to receive a client certificate as a server

### DIFF
--- a/src/lib/libtls/tls.c
+++ b/src/lib/libtls/tls.c
@@ -362,3 +362,25 @@ tls_close(struct tls *ctx)
 
 	return (rv);
 }
+
+int
+tls_get_cert_fingerprint(struct tls *ctx, char *buf, size_t buflen)
+{
+	X509 *cert;
+
+	if (buflen < SHA_DIGEST_LENGTH + 1) {
+		tls_set_error(ctx, "buflen too small");
+		return -1;
+	}
+
+	if ((cert = SSL_get_peer_certificate(ctx->ssl_conn)) == NULL) {
+		tls_set_error(ctx, "no peer certificate");
+		return -1;
+	}
+
+	strlcpy(buf, cert->sha1_hash, SHA_DIGEST_LENGTH + 1);
+
+	X509_free(cert);
+
+	return 0;
+}

--- a/src/lib/libtls/tls.h
+++ b/src/lib/libtls/tls.h
@@ -95,6 +95,7 @@ int tls_close(struct tls *_ctx);
 
 uint8_t *tls_load_file(const char *_file, size_t *_len, char *_password);
 
+int tls_get_cert_fingerprint(struct tls *_ctx, char *_buf, size_t _buflen);
 #ifdef __cplusplus
 }
 #endif

--- a/src/lib/libtls/tls_init.3
+++ b/src/lib/libtls/tls_init.3
@@ -53,7 +53,8 @@
 .Nm tls_accept_fds ,
 .Nm tls_accept_socket ,
 .Nm tls_read ,
-.Nm tls_write
+.Nm tls_write ,
+.Nm tls_get_cert_fingerprint
 .Nd TLS client and server API
 .Sh SYNOPSIS
 .In tls.h
@@ -128,6 +129,8 @@
 .Fn tls_read "struct tls *ctx" "void *buf" "size_t buflen" "size_t *outlen"
 .Ft "int"
 .Fn tls_write "struct tls *ctx" "const void *buf" "size_t buflen" "size_t *outlen"
+.Ft "int"
+.Fn tls_get_cert_fingerprint "struct tls *ctx" "char *buf" "size_t buflen"
 .Sh DESCRIPTION
 The
 .Nm tls
@@ -399,6 +402,16 @@ bytes of data from
 to the socket.
 The amount of data written is returned in
 .Fa outlen .
+.It
+.Fn tls_get_cert_fingerprint
+if
+.Fa buf
+and
+.Fa buflen
+are large enough, and the peer has provided a certificate, copies the peer's
+.Fa sha1_hash
+into the
+.Fa buf .
 .El
 .Sh RETURN VALUES
 Functions that return


### PR DESCRIPTION
Verification can be disabled similarly to the way the client works.

Additionally, this PR adds the ability to get the sha1_hash of the certificate presented