### PR TITLE
Add OPENSSL_NO_EGD to opensslfeatures.h

### DIFF
--- a/src/lib/libssl/src/crypto/opensslfeatures.h
+++ b/src/lib/libssl/src/crypto/opensslfeatures.h
@@ -1,6 +1,7 @@
 # define OPENSSL_NO_EC_NISTP_64_GCC_128
 # define OPENSSL_NO_CMS
 # define OPENSSL_NO_COMP
+# define OPENSSL_NO_EGD
 # define OPENSSL_NO_GMP
 # define OPENSSL_NO_JPAKE
 # define OPENSSL_NO_KRB5


### PR DESCRIPTION
The RAND_egd method has been removed very early on in the creation of LibreSSL yet is has not appeared in the opensslfeatures.h header file. This complicates porting a number of packages that rely on the availability of RAND_egd. I've implemented configure changes for many of these (and upstreamed them) but I believe the proper place would be to add it to de features headers.
Once added I will update all the projects that I know require patching for RAND_egd with this changed behaviour. For a list of affected ports see https://wiki.freebsd.org/LibreSSL#Ports