### PR TITLE
srtp.h: remove duplicate declaration of SSL_get_selected_srtp_profile.

### DIFF
--- a/src/lib/libssl/src/ssl/srtp.h
+++ b/src/lib/libssl/src/ssl/srtp.h
@@ -131,7 +131,6 @@ extern "C" {
 
 int SSL_CTX_set_tlsext_use_srtp(SSL_CTX *ctx, const char *profiles);
 int SSL_set_tlsext_use_srtp(SSL *ctx, const char *profiles);
-SRTP_PROTECTION_PROFILE *SSL_get_selected_srtp_profile(SSL *s);
 
 STACK_OF(SRTP_PROTECTION_PROFILE) *SSL_get_srtp_profiles(SSL *ssl);
 SRTP_PROTECTION_PROFILE *SSL_get_selected_srtp_profile(SSL *s);


### PR DESCRIPTION
The duplicate declaration can cause many warnings depending upon the compiler settings. This dup was inherited from the OpenSSL fork.