### PR TITLE
OPENSSL_cpu_caps addition breaks build

### DIFF
--- a/src/lib/libssl/src/crypto/crypto.h
+++ b/src/lib/libssl/src/crypto/crypto.h
@@ -116,6 +116,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdint.h>
 
 #ifndef HEADER_CRYPTO_H
 #define HEADER_CRYPTO_H


### PR DESCRIPTION
uint64_t OPENSSL_cpu_caps(void);

Adding `<stdint.h>` fixes this. Not sure if it's the right place.