### PR TITLE
DSA inversion fix, simplification and clean.

### DIFF
--- a/src/lib/libssl/src/crypto/dsa/dsa.h
+++ b/src/lib/libssl/src/crypto/dsa/dsa.h
@@ -89,12 +89,8 @@
 #endif
 
 #define DSA_FLAG_CACHE_MONT_P	0x01
-#define DSA_FLAG_NO_EXP_CONSTTIME       0x02 /* new with 0.9.7h; the built-in DSA
-                                              * implementation now uses constant time
-                                              * modular exponentiation for secret exponents
-                                              * by default. This flag causes the
-                                              * faster variable sliding window method to
-                                              * be used for all exponents.
+#define DSA_FLAG_NO_EXP_CONSTTIME       0x00 /* Does nothing. Previously this switched off 
+                                              * constant time behaviour.
                                               */
 
 /* If this flag is set the DSA method is FIPS compliant and can be used

--- a/src/lib/libssl/src/crypto/dsa/dsa_key.c
+++ b/src/lib/libssl/src/crypto/dsa/dsa_key.c
@@ -104,18 +104,18 @@ dsa_builtin_keygen(DSA *dsa)
 		pub_key=dsa->pub_key;
 	
 	{
-		BIGNUM local_prk;
-		BIGNUM *prk;
+		BIGNUM *prk = BN_new();
 
-		if ((dsa->flags & DSA_FLAG_NO_EXP_CONSTTIME) == 0) {
-			BN_init(&local_prk);
-			prk = &local_prk;
-			BN_with_flags(prk, priv_key, BN_FLG_CONSTTIME);
-		} else
-			prk = priv_key;
-
-		if (!BN_mod_exp(pub_key, dsa->g, prk, dsa->p, ctx))
+		if (prk == NULL)
 			goto err;
+
+		BN_with_flags(prk, priv_key, BN_FLG_CONSTTIME);
+
+		if (!BN_mod_exp(pub_key, dsa->g, prk, dsa->p, ctx)) {
+			BN_free(prk);
+			goto err;
+		}
+		BN_free(prk);
 	}
 
 	dsa->priv_key = priv_key;


### PR DESCRIPTION
The recent change in DSA introduced a bug, the inversion was performed in non-constant time.
Additionally, the DSA flag DSA_FLAG_NO_EXP_CONSTTIME is not used and therefore the code is simplified and cleaned.