### PR TITLE
Deprecate flags DH_FLAG_NO_EXP_CONSTTIME and RSA_FLAG_NO_CONSTTIME

### DIFF
--- a/src/lib/libssl/src/crypto/dh/dh.h
+++ b/src/lib/libssl/src/crypto/dh/dh.h
@@ -78,12 +78,8 @@
 #endif
 
 #define DH_FLAG_CACHE_MONT_P     0x01
-#define DH_FLAG_NO_EXP_CONSTTIME 0x02 /* new with 0.9.7h; the built-in DH
-                                       * implementation now uses constant time
-                                       * modular exponentiation for secret exponents
-                                       * by default. This flag causes the
-                                       * faster variable sliding window method to
-                                       * be used for all exponents.
+#define DH_FLAG_NO_EXP_CONSTTIME 0x00 /* Does nothing. Previously this switched off 
+                                       * constant time behaviour.
                                        */
 
 /* If this flag is set the DH method is FIPS compliant and can be used

--- a/src/lib/libssl/src/crypto/dh/dh_key.c
+++ b/src/lib/libssl/src/crypto/dh/dh_key.c
@@ -147,19 +147,19 @@ generate_key(DH *dh)
 	}
 
 	{
-		BIGNUM local_prk;
-		BIGNUM *prk;
+		BIGNUM *prk = BN_new();
 
-		if ((dh->flags & DH_FLAG_NO_EXP_CONSTTIME) == 0) {
-			BN_init(&local_prk);
-			prk = &local_prk;
-			BN_with_flags(prk, priv_key, BN_FLG_CONSTTIME);
-		} else
-			prk = priv_key;
+		if (prk == NULL)
+			goto err;
+
+		BN_with_flags(prk, priv_key, BN_FLG_CONSTTIME);
 
 		if (!dh->meth->bn_mod_exp(dh, pub_key, dh->g, prk, dh->p, ctx,
-		    mont))
+		    mont)) {
+			BN_free(prk);
 			goto err;
+		}
+		BN_free(prk);
 	}
 		
 	dh->pub_key = pub_key;
@@ -206,10 +206,9 @@ compute_key(unsigned char *key, const BIGNUM *pub_key, DH *dh)
 	if (dh->flags & DH_FLAG_CACHE_MONT_P) {
 		mont = BN_MONT_CTX_set_locked(&dh->method_mont_p,
 		    CRYPTO_LOCK_DH, dh->p, ctx);
-		if ((dh->flags & DH_FLAG_NO_EXP_CONSTTIME) == 0) {
-			/* XXX */
-			BN_set_flags(dh->priv_key, BN_FLG_CONSTTIME);
-		}
+
+		BN_set_flags(dh->priv_key, BN_FLG_CONSTTIME);
+
 		if (!mont)
 			goto err;
 	}
@@ -238,16 +237,7 @@ static int
 dh_bn_mod_exp(const DH *dh, BIGNUM *r, const BIGNUM *a, const BIGNUM *p,
     const BIGNUM *m, BN_CTX *ctx, BN_MONT_CTX *m_ctx)
 {
-	/*
-	 * If a is only one word long and constant time is false, use the faster
-	 * exponenentiation function.
-	 */
-	if (a->top == 1 && (dh->flags & DH_FLAG_NO_EXP_CONSTTIME) != 0) {
-		BN_ULONG A = a->d[0];
-
-		return BN_mod_exp_mont_word(r, A, p, m, ctx, m_ctx);
-	} else
-		return BN_mod_exp_mont(r, a, p, m, ctx, m_ctx);
+	return BN_mod_exp_mont(r, a, p, m, ctx, m_ctx);
 }
 
 static int

--- a/src/lib/libssl/src/crypto/rsa/rsa.h
+++ b/src/lib/libssl/src/crypto/rsa/rsa.h
@@ -195,13 +195,9 @@ struct rsa_st {
 #define RSA_FLAG_NO_BLINDING		0x0080
 
 /*
- * The built-in RSA implementation uses constant time operations by default
- * in private key operations, e.g., constant time modular exponentiation,
- * modular inverse without leaking branches, division without leaking branches.
- * This flag disables these constant time operations and results in faster RSA
- * private key operations.
+ * Does nothing. Previously this switched off constant time behaviour.
  */
-#define RSA_FLAG_NO_CONSTTIME		0x0100
+#define RSA_FLAG_NO_CONSTTIME		0x0000
 
 
 #define EVP_PKEY_CTX_set_rsa_padding(ctx, pad) \

--- a/src/lib/libssl/src/crypto/rsa/rsa_crpt.c
+++ b/src/lib/libssl/src/crypto/rsa/rsa_crpt.c
@@ -169,8 +169,8 @@ err:
 BN_BLINDING *
 RSA_setup_blinding(RSA *rsa, BN_CTX *in_ctx)
 {
-	BIGNUM local_n;
-	BIGNUM *e, *n;
+	BIGNUM *e;
+	BIGNUM *n = BN_new();
 	BN_CTX *ctx;
 	BN_BLINDING *ret = NULL;
 
@@ -192,15 +192,16 @@ RSA_setup_blinding(RSA *rsa, BN_CTX *in_ctx)
 	} else
 		e = rsa->e;
 
-	if (!(rsa->flags & RSA_FLAG_NO_CONSTTIME)) {
-		/* Set BN_FLG_CONSTTIME flag */
-		n = &local_n;
-		BN_with_flags(n, rsa->n, BN_FLG_CONSTTIME);
-	} else
-		n = rsa->n;
+	if (n == NULL)
+		goto err;
 
+	BN_with_flags(n, rsa->n, BN_FLG_CONSTTIME);
+	
 	ret = BN_BLINDING_create_param(NULL, e, n, ctx, rsa->meth->bn_mod_exp,
 	    rsa->_method_mod_n);
+
+	BN_free(n);
+
 	if (ret == NULL) {
 		RSAerr(RSA_F_RSA_SETUP_BLINDING, ERR_R_BN_LIB);
 		goto err;

--- a/src/lib/libssl/src/crypto/rsa/rsa_gen.c
+++ b/src/lib/libssl/src/crypto/rsa/rsa_gen.c
@@ -91,7 +91,9 @@ rsa_builtin_keygen(RSA *rsa, int bits, BIGNUM *e_value, BN_GENCB *cb)
 {
 	BIGNUM *r0 = NULL, *r1 = NULL, *r2 = NULL, *r3 = NULL, *tmp;
 	BIGNUM local_r0, local_d, local_p;
-	BIGNUM *pr0, *d, *p;
+	BIGNUM *pr0 = BN_new();
+	BIGNUM *d = BN_new();
+	BIGNUM *p = BN_new();
 	int bitsp, bitsq, ok = -1, n = 0;
 	BN_CTX *ctx = NULL;
 
@@ -193,37 +195,39 @@ rsa_builtin_keygen(RSA *rsa, int bits, BIGNUM *e_value, BN_GENCB *cb)
 		goto err;
 	if (!BN_mul(r0, r1, r2, ctx))			/* (p-1)(q-1) */
 		goto err;
-	if (!(rsa->flags & RSA_FLAG_NO_CONSTTIME)) {
-		pr0 = &local_r0;
-		BN_with_flags(pr0, r0, BN_FLG_CONSTTIME);
-	} else
-		pr0 = r0;
-	if (!BN_mod_inverse(rsa->d, rsa->e, pr0, ctx))	/* d */
+	if (pr0 == NULL)
 		goto err;
+	BN_with_flags(pr0, r0, BN_FLG_CONSTTIME);
+	if (!BN_mod_inverse(rsa->d, rsa->e, pr0, ctx)) { /* d */
+		BN_free(pr0);
+		goto err;
+	}
 
 	/* set up d for correct BN_FLG_CONSTTIME flag */
-	if (!(rsa->flags & RSA_FLAG_NO_CONSTTIME)) {
-		d = &local_d;
-		BN_with_flags(d, rsa->d, BN_FLG_CONSTTIME);
-	} else
-		d = rsa->d;
+	if (d == NULL)
+		goto err;
+	BN_with_flags(d, rsa->d, BN_FLG_CONSTTIME);
 
 	/* calculate d mod (p-1) */
-	if (!BN_mod(rsa->dmp1, d, r1, ctx))
+	if (!BN_mod(rsa->dmp1, d, r1, ctx)) {
+		BN_free(d);
 		goto err;
+	}
 
 	/* calculate d mod (q-1) */
-	if (!BN_mod(rsa->dmq1, d, r2, ctx))
+	if (!BN_mod(rsa->dmq1, d, r2, ctx)) {
+		BN_free(d);
 		goto err;
+	}
 
 	/* calculate inverse of q mod p */
-	if (!(rsa->flags & RSA_FLAG_NO_CONSTTIME)) {
-		p = &local_p;
-		BN_with_flags(p, rsa->p, BN_FLG_CONSTTIME);
-	} else
-		p = rsa->p;
-	if (!BN_mod_inverse(rsa->iqmp, rsa->q, p, ctx))
+	if (p == NULL)
 		goto err;
+	BN_with_flags(p, rsa->p, BN_FLG_CONSTTIME);
+	if (!BN_mod_inverse(rsa->iqmp, rsa->q, p, ctx)) {
+		BN_free(p);
+		goto err;
+	}
 
 	ok = 1;
 err:


### PR DESCRIPTION
Previously switched off constant time implementations for DH and RSA.


