### PR TITLE
Fix ocspcheck build issues on FreeBSD

### DIFF
--- a/src/usr.sbin/ocspcheck/http.c
+++ b/src/usr.sbin/ocspcheck/http.c
@@ -18,6 +18,7 @@
 #include <sys/socket.h>
 #include <sys/param.h>
 #include <arpa/inet.h>
+#include <netinet/in.h>
 
 #include <ctype.h>
 #include <err.h>

--- a/src/usr.sbin/ocspcheck/ocspcheck.c
+++ b/src/usr.sbin/ocspcheck/ocspcheck.c
@@ -16,6 +16,7 @@
 
 #include <arpa/inet.h>
 #include <sys/socket.h>
+#include <netinet/in.h>
 #include <sys/stat.h>
 
 #include <err.h>
@@ -76,7 +77,9 @@ host_dns(const char *s, struct addr vec[MAX_SERVERS_DNS])
 	error = getaddrinfo(s, NULL, &hints, &res0);
 
 	if (error == EAI_AGAIN ||
+#ifdef EAI_NODATA
 	    error == EAI_NODATA ||
+#endif
 	    error == EAI_NONAME)
 		return(0);
 


### PR DESCRIPTION
  - include netinet/in.h for sockaddr_in
  - EAI_NODATA was removed in 2003 [1]

[1]: https://svnweb.freebsd.org/changeset/base/121472