### PR TITLE
Fix build with musl and older Linux kernel

### DIFF
--- a/src/lib/libcrypto/arc4random/getentropy_linux.c
+++ b/src/lib/libcrypto/arc4random/getentropy_linux.c
@@ -194,6 +194,11 @@ gotdata(char *buf, size_t len)
 }
 
 #ifdef SYS_getrandom
+
+#ifndef GRND_NONBLOCK
+#define GRND_NONBLOCK	0x0001
+#endif
+
 static int
 getentropy_getrandom(void *buf, size_t len)
 {


### PR DESCRIPTION
The musl libc carries its own copy of Linux system calls. When building
with Linux headers older than v3.17, musl provides SYS_getrandom
definition, but not GRND_NONBLOCK. This causes build failure for
libressl and openntpd:

getentropy_linux.c: In function 'getentropy_getrandom':
getentropy_linux.c:205:42: error: 'GRND_NONBLOCK' undeclared (first use in this function)
   ret = syscall(SYS_getrandom, buf, len, GRND_NONBLOCK);
                                          ^~~~~~~~~~~~~

Define GRND_NONBLOCK locally when its definition is missing to fix the
build. There should be no run-time effect. Older kernels return ENOSYS
for unsupported syscall().