### PR TITLE
Make X509_check_host and X509_check_email calculate strlen if chklen …

### DIFF
--- a/src/lib/libcrypto/x509v3/v3_utl.c
+++ b/src/lib/libcrypto/x509v3/v3_utl.c
@@ -1015,8 +1015,17 @@ int X509_check_host(X509 *x, const char *chk, size_t chklen,
 {
 	if (chk == NULL)
 		return -2;
-	if (memchr(chk, '\0', chklen))
+	/*
+	 * Embedded NULs are disallowed, except as the last character of a
+	 * string of length 2 or more (tolerate caller including terminating
+	 * NUL in string length).
+	 */
+	if (chklen == 0)
+		chklen = strlen(chk);
+	else if (memchr(chk, '\0', chklen > 1 ? chklen - 1 : chklen))
 		return -2;
+	if (chklen > 1 && chk[chklen - 1] == '\0')
+		--chklen;
 	return do_x509_check(x, chk, chklen, flags, GEN_DNS, peername);
 }
 
@@ -1025,8 +1034,17 @@ int X509_check_email(X509 *x, const char *chk, size_t chklen,
 {
 	if (chk == NULL)
 		return -2;
-	if (memchr(chk, '\0', chklen))
+	/*
+	 * Embedded NULs are disallowed, except as the last character of a
+	 * string of length 2 or more (tolerate caller including terminating
+	 * NUL in string length).
+	 */
+	if (chklen == 0)
+		chklen = strlen(chk);
+	else if (memchr(chk, '\0', chklen > 1 ? chklen - 1 : chklen))
 		return -2;
+	if (chklen > 1 && chk[chklen - 1] == '\0')
+		--chklen;
 	return do_x509_check(x, chk, chklen, flags, GEN_EMAIL, NULL);
 }
 


### PR DESCRIPTION
…is 0.

According to the X509_check_host(3) (src/lib/libcrypto/man/X509_check_host.3),
"The namelen argument must be the number of characters in the name string or zero,
in which case the length is calculated with strlen(name)" for both functions
mentioned above. Even though I think this not a good API (I would always make
the called pass the exact length and call it a day), this causes compatibility
problems with code written for OpenSSL, a good example is MariaDB's SSL certificate
hostname check found here:
https://github.com/MariaDB/server/blob/10.3/sql-common/client.c#L1825

This change uses the code from OpenSSL's, which on top of calculating the
string length also tolerates the caller including terminating NUL in string
length. This way, LibreSSL's code should be API compatible with OpenSSL's
interface. It would be good to add unit tests for these functions.