### PR TITLE
free keypair memory properly upon failure

### DIFF
--- a/src/lib/libtls/tls_config.c
+++ b/src/lib/libtls/tls_config.c
@@ -124,6 +124,7 @@ tls_config_new(void)
 	return (config);
 
  err:
+	tls_keypair_free(config->keypair);
 	tls_config_free(config);
 	return (NULL);
 }


### PR DESCRIPTION
Upon failure in tls_config_new, memory of tls_keypair need to be released as well