### PR TITLE
Add SM3

### DIFF
--- a/src/lib/libcrypto/Makefile
+++ b/src/lib/libcrypto/Makefile
@@ -153,7 +153,7 @@ SRCS+= encode.c digest.c evp_enc.c evp_key.c
 SRCS+= e_des.c e_bf.c e_idea.c e_des3.c e_camellia.c
 SRCS+= e_rc4.c e_aes.c names.c
 SRCS+= e_xcbc_d.c e_rc2.c e_cast.c
-SRCS+= m_null.c m_md4.c m_md5.c m_sha1.c m_wp.c
+SRCS+= m_null.c m_md4.c m_md5.c m_sha1.c m_sm3.c m_wp.c
 SRCS+= m_dss.c m_dss1.c m_ripemd.c m_ecdsa.c
 SRCS+= p_open.c p_seal.c p_sign.c p_verify.c p_lib.c p_enc.c p_dec.c
 SRCS+= bio_md.c bio_b64.c bio_enc.c evp_err.c e_null.c
@@ -232,6 +232,9 @@ SRCS+= rsa_pmeth.c rsa_crpt.c rsa_meth.c
 
 # sha/
 SRCS+= sha1dgst.c sha1_one.c sha256.c sha512.c
+
+# sm3/
+SRCS+= sm3.c
 
 # stack/
 SRCS+= stack.c
@@ -312,6 +315,7 @@ SRCS+= pcy_cache.c pcy_node.c pcy_data.c pcy_map.c pcy_tree.c pcy_lib.c
 	${LCRYPTO_SRC}/ripemd \
 	${LCRYPTO_SRC}/rsa \
 	${LCRYPTO_SRC}/sha \
+	${LCRYPTO_SRC}/sm3 \
 	${LCRYPTO_SRC}/stack \
 	${LCRYPTO_SRC}/threads \
 	${LCRYPTO_SRC}/ts \
@@ -373,6 +377,7 @@ HDRS=\
 	${LCRYPTO_SRC}/ripemd/ripemd.h \
 	${LCRYPTO_SRC}/rsa/rsa.h \
 	${LCRYPTO_SRC}/sha/sha.h \
+	${LCRYPTO_SRC}/sm3/sm3.h \
 	${LCRYPTO_SRC}/stack/safestack.h \
 	${LCRYPTO_SRC}/stack/stack.h \
 	${LCRYPTO_SRC}/ts/ts.h \

--- a/src/lib/libcrypto/Symbols.list
+++ b/src/lib/libcrypto/Symbols.list
@@ -1600,6 +1600,7 @@ EVP_sha224
 EVP_sha256
 EVP_sha384
 EVP_sha512
+EVP_sm3
 EVP_streebog256
 EVP_streebog512
 EVP_whirlpool
@@ -2337,6 +2338,9 @@ SHA512_Final
 SHA512_Init
 SHA512_Transform
 SHA512_Update
+SM3_Final
+SM3_Init
+SM3_Update
 SMIME_crlf_copy
 SMIME_read_ASN1
 SMIME_read_PKCS7

--- a/src/lib/libcrypto/evp/evp.h
+++ b/src/lib/libcrypto/evp/evp.h
@@ -681,6 +681,9 @@ const EVP_MD *EVP_sha256(void);
 const EVP_MD *EVP_sha384(void);
 const EVP_MD *EVP_sha512(void);
 #endif
+#ifndef OPENSSL_NO_SM3
+const EVP_MD *EVP_sm3(void);
+#endif
 #ifndef OPENSSL_NO_RIPEMD
 const EVP_MD *EVP_ripemd160(void);
 #endif

--- a/src/lib/libcrypto/evp/m_sm3.c
+++ b/src/lib/libcrypto/evp/m_sm3.c
@@ -1,0 +1,68 @@
+/*
+* Copyright (c) 2018, Ribose Inc
+*
+* Permission to use, copy, modify, and/or distribute this software for any
+* purpose with or without fee is hereby granted, provided that the above
+* copyright notice and this permission notice appear in all copies.
+*
+* THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+* WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+* MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+* SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+* WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+* OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+* CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+
+#include <openssl/opensslconf.h>
+
+#ifndef OPENSSL_NO_SM3
+# include <openssl/evp.h>
+# include <openssl/sm3.h>
+
+#ifndef OPENSSL_NO_RSA
+#include <openssl/rsa.h>
+#endif
+
+static int init(EVP_MD_CTX *ctx)
+{
+    return SM3_Init(ctx->md_data);
+}
+
+static int update(EVP_MD_CTX *ctx, const void *data, size_t count)
+{
+    return SM3_Update(ctx->md_data, data, count);
+}
+
+static int final(EVP_MD_CTX *ctx, unsigned char *md)
+{
+    return SM3_Final(md, ctx->md_data);
+}
+
+static const EVP_MD sm3_md = {
+	.type = NID_sm3,
+	.pkey_type = NID_sm3WithRSAEncryption,
+	.md_size = SM3_DIGEST_LENGTH,
+	.flags = EVP_MD_FLAG_PKEY_METHOD_SIGNATURE|EVP_MD_FLAG_DIGALGID_ABSENT,
+	.init = init,
+	.update = update,
+	.final = final,
+	.copy = NULL,
+	.cleanup = NULL,
+#ifndef OPENSSL_NO_RSA
+	.sign = (evp_sign_method *)RSA_sign,
+	.verify = (evp_verify_method *)RSA_verify,
+	.required_pkey_type = {
+		EVP_PKEY_RSA, EVP_PKEY_RSA2, 0, 0,
+	},
+#endif
+	.block_size = SM3_CBLOCK,
+	.ctx_size = sizeof(EVP_MD *) + sizeof(SM3_CTX),
+};
+
+const EVP_MD *EVP_sm3(void)
+{
+    return &sm3_md;
+}
+
+#endif

--- a/src/lib/libcrypto/objects/objects.txt
+++ b/src/lib/libcrypto/objects/objects.txt
@@ -1234,6 +1234,11 @@ cryptocom 1 3 4		: id-GostR3411-94-with-GostR3410-2001-cc : GOST R 34.11-94 with
 
 cryptocom 1 8 1		: id-GostR3410-2001-ParamSet-cc : GOST R 3410-2001 Parameter Set Cryptocom
 
+# Definitions for SM3
+
+1 2 156 10197 1 401 : SM3     : sm3
+1 2 156 10197 1 501 : RSA-SM3 : sm3WithRSAEncryption
+
 # Definitions for Camellia cipher - CBC MODE
 
 1 2 392 200011 61 1 1 1 2 : CAMELLIA-128-CBC		: camellia-128-cbc

--- a/src/lib/libcrypto/sm3/sm3.c
+++ b/src/lib/libcrypto/sm3/sm3.c
@@ -1,0 +1,201 @@
+/*
+* Copyright (c) 2018, Ribose Inc
+*
+* Permission to use, copy, modify, and/or distribute this software for any
+* purpose with or without fee is hereby granted, provided that the above
+* copyright notice and this permission notice appear in all copies.
+*
+* THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+* WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+* MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+* SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+* WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+* OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+* CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+
+#include <openssl/sm3.h>
+#include "sm3_locl.h"
+
+int SM3_Init(SM3_CTX *c)
+{
+    memset(c, 0, sizeof(*c));
+    c->A = SM3_A;
+    c->B = SM3_B;
+    c->C = SM3_C;
+    c->D = SM3_D;
+    c->E = SM3_E;
+    c->F = SM3_F;
+    c->G = SM3_G;
+    c->H = SM3_H;
+    return 1;
+}
+
+void SM3_block_data_order(SM3_CTX *ctx, const void *p, size_t num)
+{
+    const unsigned char *data = p;
+    SM3_WORD A, B, C, D, E, F, G, H;
+
+    SM3_WORD W00, W01, W02, W03, W04, W05, W06, W07,
+        W08, W09, W10, W11, W12, W13, W14, W15;
+
+    for (; num--;) {
+
+        A = ctx->A;
+        B = ctx->B;
+        C = ctx->C;
+        D = ctx->D;
+        E = ctx->E;
+        F = ctx->F;
+        G = ctx->G;
+        H = ctx->H;
+
+        /*
+        * We have to load all message bytes immediately since SM3 reads
+        * them slightly out of order.
+        */
+        (void)HOST_c2l(data, W00);
+        (void)HOST_c2l(data, W01);
+        (void)HOST_c2l(data, W02);
+        (void)HOST_c2l(data, W03);
+        (void)HOST_c2l(data, W04);
+        (void)HOST_c2l(data, W05);
+        (void)HOST_c2l(data, W06);
+        (void)HOST_c2l(data, W07);
+        (void)HOST_c2l(data, W08);
+        (void)HOST_c2l(data, W09);
+        (void)HOST_c2l(data, W10);
+        (void)HOST_c2l(data, W11);
+        (void)HOST_c2l(data, W12);
+        (void)HOST_c2l(data, W13);
+        (void)HOST_c2l(data, W14);
+        (void)HOST_c2l(data, W15);
+
+        R1(A, B, C, D, E, F, G, H, 0x79CC4519, W00, W00 ^ W04);
+        W00 = EXPAND(W00, W07, W13, W03, W10);
+        R1(D, A, B, C, H, E, F, G, 0xF3988A32, W01, W01 ^ W05);
+        W01 = EXPAND(W01, W08, W14, W04, W11);
+        R1(C, D, A, B, G, H, E, F, 0xE7311465, W02, W02 ^ W06);
+        W02 = EXPAND(W02, W09, W15, W05, W12);
+        R1(B, C, D, A, F, G, H, E, 0xCE6228CB, W03, W03 ^ W07);
+        W03 = EXPAND(W03, W10, W00, W06, W13);
+        R1(A, B, C, D, E, F, G, H, 0x9CC45197, W04, W04 ^ W08);
+        W04 = EXPAND(W04, W11, W01, W07, W14);
+        R1(D, A, B, C, H, E, F, G, 0x3988A32F, W05, W05 ^ W09);
+        W05 = EXPAND(W05, W12, W02, W08, W15);
+        R1(C, D, A, B, G, H, E, F, 0x7311465E, W06, W06 ^ W10);
+        W06 = EXPAND(W06, W13, W03, W09, W00);
+        R1(B, C, D, A, F, G, H, E, 0xE6228CBC, W07, W07 ^ W11);
+        W07 = EXPAND(W07, W14, W04, W10, W01);
+        R1(A, B, C, D, E, F, G, H, 0xCC451979, W08, W08 ^ W12);
+        W08 = EXPAND(W08, W15, W05, W11, W02);
+        R1(D, A, B, C, H, E, F, G, 0x988A32F3, W09, W09 ^ W13);
+        W09 = EXPAND(W09, W00, W06, W12, W03);
+        R1(C, D, A, B, G, H, E, F, 0x311465E7, W10, W10 ^ W14);
+        W10 = EXPAND(W10, W01, W07, W13, W04);
+        R1(B, C, D, A, F, G, H, E, 0x6228CBCE, W11, W11 ^ W15);
+        W11 = EXPAND(W11, W02, W08, W14, W05);
+        R1(A, B, C, D, E, F, G, H, 0xC451979C, W12, W12 ^ W00);
+        W12 = EXPAND(W12, W03, W09, W15, W06);
+        R1(D, A, B, C, H, E, F, G, 0x88A32F39, W13, W13 ^ W01);
+        W13 = EXPAND(W13, W04, W10, W00, W07);
+        R1(C, D, A, B, G, H, E, F, 0x11465E73, W14, W14 ^ W02);
+        W14 = EXPAND(W14, W05, W11, W01, W08);
+        R1(B, C, D, A, F, G, H, E, 0x228CBCE6, W15, W15 ^ W03);
+        W15 = EXPAND(W15, W06, W12, W02, W09);
+        R2(A, B, C, D, E, F, G, H, 0x9D8A7A87, W00, W00 ^ W04);
+        W00 = EXPAND(W00, W07, W13, W03, W10);
+        R2(D, A, B, C, H, E, F, G, 0x3B14F50F, W01, W01 ^ W05);
+        W01 = EXPAND(W01, W08, W14, W04, W11);
+        R2(C, D, A, B, G, H, E, F, 0x7629EA1E, W02, W02 ^ W06);
+        W02 = EXPAND(W02, W09, W15, W05, W12);
+        R2(B, C, D, A, F, G, H, E, 0xEC53D43C, W03, W03 ^ W07);
+        W03 = EXPAND(W03, W10, W00, W06, W13);
+        R2(A, B, C, D, E, F, G, H, 0xD8A7A879, W04, W04 ^ W08);
+        W04 = EXPAND(W04, W11, W01, W07, W14);
+        R2(D, A, B, C, H, E, F, G, 0xB14F50F3, W05, W05 ^ W09);
+        W05 = EXPAND(W05, W12, W02, W08, W15);
+        R2(C, D, A, B, G, H, E, F, 0x629EA1E7, W06, W06 ^ W10);
+        W06 = EXPAND(W06, W13, W03, W09, W00);
+        R2(B, C, D, A, F, G, H, E, 0xC53D43CE, W07, W07 ^ W11);
+        W07 = EXPAND(W07, W14, W04, W10, W01);
+        R2(A, B, C, D, E, F, G, H, 0x8A7A879D, W08, W08 ^ W12);
+        W08 = EXPAND(W08, W15, W05, W11, W02);
+        R2(D, A, B, C, H, E, F, G, 0x14F50F3B, W09, W09 ^ W13);
+        W09 = EXPAND(W09, W00, W06, W12, W03);
+        R2(C, D, A, B, G, H, E, F, 0x29EA1E76, W10, W10 ^ W14);
+        W10 = EXPAND(W10, W01, W07, W13, W04);
+        R2(B, C, D, A, F, G, H, E, 0x53D43CEC, W11, W11 ^ W15);
+        W11 = EXPAND(W11, W02, W08, W14, W05);
+        R2(A, B, C, D, E, F, G, H, 0xA7A879D8, W12, W12 ^ W00);
+        W12 = EXPAND(W12, W03, W09, W15, W06);
+        R2(D, A, B, C, H, E, F, G, 0x4F50F3B1, W13, W13 ^ W01);
+        W13 = EXPAND(W13, W04, W10, W00, W07);
+        R2(C, D, A, B, G, H, E, F, 0x9EA1E762, W14, W14 ^ W02);
+        W14 = EXPAND(W14, W05, W11, W01, W08);
+        R2(B, C, D, A, F, G, H, E, 0x3D43CEC5, W15, W15 ^ W03);
+        W15 = EXPAND(W15, W06, W12, W02, W09);
+        R2(A, B, C, D, E, F, G, H, 0x7A879D8A, W00, W00 ^ W04);
+        W00 = EXPAND(W00, W07, W13, W03, W10);
+        R2(D, A, B, C, H, E, F, G, 0xF50F3B14, W01, W01 ^ W05);
+        W01 = EXPAND(W01, W08, W14, W04, W11);
+        R2(C, D, A, B, G, H, E, F, 0xEA1E7629, W02, W02 ^ W06);
+        W02 = EXPAND(W02, W09, W15, W05, W12);
+        R2(B, C, D, A, F, G, H, E, 0xD43CEC53, W03, W03 ^ W07);
+        W03 = EXPAND(W03, W10, W00, W06, W13);
+        R2(A, B, C, D, E, F, G, H, 0xA879D8A7, W04, W04 ^ W08);
+        W04 = EXPAND(W04, W11, W01, W07, W14);
+        R2(D, A, B, C, H, E, F, G, 0x50F3B14F, W05, W05 ^ W09);
+        W05 = EXPAND(W05, W12, W02, W08, W15);
+        R2(C, D, A, B, G, H, E, F, 0xA1E7629E, W06, W06 ^ W10);
+        W06 = EXPAND(W06, W13, W03, W09, W00);
+        R2(B, C, D, A, F, G, H, E, 0x43CEC53D, W07, W07 ^ W11);
+        W07 = EXPAND(W07, W14, W04, W10, W01);
+        R2(A, B, C, D, E, F, G, H, 0x879D8A7A, W08, W08 ^ W12);
+        W08 = EXPAND(W08, W15, W05, W11, W02);
+        R2(D, A, B, C, H, E, F, G, 0x0F3B14F5, W09, W09 ^ W13);
+        W09 = EXPAND(W09, W00, W06, W12, W03);
+        R2(C, D, A, B, G, H, E, F, 0x1E7629EA, W10, W10 ^ W14);
+        W10 = EXPAND(W10, W01, W07, W13, W04);
+        R2(B, C, D, A, F, G, H, E, 0x3CEC53D4, W11, W11 ^ W15);
+        W11 = EXPAND(W11, W02, W08, W14, W05);
+        R2(A, B, C, D, E, F, G, H, 0x79D8A7A8, W12, W12 ^ W00);
+        W12 = EXPAND(W12, W03, W09, W15, W06);
+        R2(D, A, B, C, H, E, F, G, 0xF3B14F50, W13, W13 ^ W01);
+        W13 = EXPAND(W13, W04, W10, W00, W07);
+        R2(C, D, A, B, G, H, E, F, 0xE7629EA1, W14, W14 ^ W02);
+        W14 = EXPAND(W14, W05, W11, W01, W08);
+        R2(B, C, D, A, F, G, H, E, 0xCEC53D43, W15, W15 ^ W03);
+        W15 = EXPAND(W15, W06, W12, W02, W09);
+        R2(A, B, C, D, E, F, G, H, 0x9D8A7A87, W00, W00 ^ W04);
+        W00 = EXPAND(W00, W07, W13, W03, W10);
+        R2(D, A, B, C, H, E, F, G, 0x3B14F50F, W01, W01 ^ W05);
+        W01 = EXPAND(W01, W08, W14, W04, W11);
+        R2(C, D, A, B, G, H, E, F, 0x7629EA1E, W02, W02 ^ W06);
+        W02 = EXPAND(W02, W09, W15, W05, W12);
+        R2(B, C, D, A, F, G, H, E, 0xEC53D43C, W03, W03 ^ W07);
+        W03 = EXPAND(W03, W10, W00, W06, W13);
+        R2(A, B, C, D, E, F, G, H, 0xD8A7A879, W04, W04 ^ W08);
+        R2(D, A, B, C, H, E, F, G, 0xB14F50F3, W05, W05 ^ W09);
+        R2(C, D, A, B, G, H, E, F, 0x629EA1E7, W06, W06 ^ W10);
+        R2(B, C, D, A, F, G, H, E, 0xC53D43CE, W07, W07 ^ W11);
+        R2(A, B, C, D, E, F, G, H, 0x8A7A879D, W08, W08 ^ W12);
+        R2(D, A, B, C, H, E, F, G, 0x14F50F3B, W09, W09 ^ W13);
+        R2(C, D, A, B, G, H, E, F, 0x29EA1E76, W10, W10 ^ W14);
+        R2(B, C, D, A, F, G, H, E, 0x53D43CEC, W11, W11 ^ W15);
+        R2(A, B, C, D, E, F, G, H, 0xA7A879D8, W12, W12 ^ W00);
+        R2(D, A, B, C, H, E, F, G, 0x4F50F3B1, W13, W13 ^ W01);
+        R2(C, D, A, B, G, H, E, F, 0x9EA1E762, W14, W14 ^ W02);
+        R2(B, C, D, A, F, G, H, E, 0x3D43CEC5, W15, W15 ^ W03);
+
+        ctx->A ^= A;
+        ctx->B ^= B;
+        ctx->C ^= C;
+        ctx->D ^= D;
+        ctx->E ^= E;
+        ctx->F ^= F;
+        ctx->G ^= G;
+        ctx->H ^= H;
+    }
+}
+

--- a/src/lib/libcrypto/sm3/sm3.h
+++ b/src/lib/libcrypto/sm3/sm3.h
@@ -1,0 +1,54 @@
+/*
+* Copyright (c) 2018, Ribose Inc
+*
+* Permission to use, copy, modify, and/or distribute this software for any
+* purpose with or without fee is hereby granted, provided that the above
+* copyright notice and this permission notice appear in all copies.
+*
+* THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+* WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+* MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+* SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+* WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+* OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+* CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+
+#ifndef HEADER_SM3_H
+#define HEADER_SM3_H
+
+# include <stddef.h>
+# include <openssl/opensslconf.h>
+
+#ifdef  __cplusplus
+extern "C" {
+#endif
+
+# ifdef OPENSSL_NO_SM3
+#  error SM3 is disabled.
+# endif
+
+# define SM3_DIGEST_LENGTH 32
+# define SM3_WORD unsigned int
+
+# define SM3_CBLOCK      64
+# define SM3_LBLOCK      (SM3_CBLOCK/4)
+
+typedef struct SM3state_st {
+   SM3_WORD A, B, C, D, E, F, G, H;
+   SM3_WORD Nl, Nh;
+   SM3_WORD data[SM3_LBLOCK];
+   unsigned int num;
+} SM3_CTX;
+
+int SM3_Init(SM3_CTX *c);
+int SM3_Update(SM3_CTX *c, const void *data, size_t len);
+int SM3_Final(unsigned char *md, SM3_CTX *c);
+
+void SM3_block_data_order(SM3_CTX *c, const void *p, size_t num);
+
+#ifdef  __cplusplus
+}
+#endif
+
+#endif

--- a/src/lib/libcrypto/sm3/sm3_locl.h
+++ b/src/lib/libcrypto/sm3/sm3_locl.h
@@ -1,0 +1,85 @@
+/*
+* Copyright (c) 2018, Ribose Inc
+*
+* Permission to use, copy, modify, and/or distribute this software for any
+* purpose with or without fee is hereby granted, provided that the above
+* copyright notice and this permission notice appear in all copies.
+*
+* THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+* WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+* MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+* SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+* WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+* OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+* CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+
+#include <string.h>
+
+#include <openssl/opensslconf.h>
+
+#define DATA_ORDER_IS_BIG_ENDIAN
+
+#define HASH_LONG               SM3_WORD
+#define HASH_CTX                SM3_CTX
+#define HASH_CBLOCK             SM3_CBLOCK
+#define HASH_UPDATE             SM3_Update
+#define HASH_TRANSFORM          SM3_Transform
+#define HASH_FINAL              SM3_Final
+#define HASH_MAKE_STRING(c, s)              \
+      do {                                  \
+        unsigned long ll;                   \
+        ll=(c)->A; (void)HOST_l2c(ll, (s)); \
+        ll=(c)->B; (void)HOST_l2c(ll, (s)); \
+        ll=(c)->C; (void)HOST_l2c(ll, (s)); \
+        ll=(c)->D; (void)HOST_l2c(ll, (s)); \
+        ll=(c)->E; (void)HOST_l2c(ll, (s)); \
+        ll=(c)->F; (void)HOST_l2c(ll, (s)); \
+        ll=(c)->G; (void)HOST_l2c(ll, (s)); \
+        ll=(c)->H; (void)HOST_l2c(ll, (s)); \
+      } while (0)
+#define HASH_BLOCK_DATA_ORDER   SM3_block_data_order
+
+void SM3_transform(SM3_CTX *c, const unsigned char *data);
+
+#include "md32_common.h"
+
+#define P0(X) (X ^ ROTATE(X, 9) ^ ROTATE(X, 17))
+#define P1(X) (X ^ ROTATE(X, 15) ^ ROTATE(X, 23))
+
+#define FF0(X,Y,Z) (X ^ Y ^ Z)
+#define GG0(X,Y,Z) (X ^ Y ^ Z)
+
+#define FF1(X,Y,Z) ((X & Y) | ((X | Y) & Z))
+#define GG1(X,Y,Z) ((Z ^ (X & (Y ^ Z))))
+
+#define EXPAND(W0,W7,W13,W3,W10) \
+   (P1(W0 ^ W7 ^ ROTATE(W13, 15)) ^ ROTATE(W3, 7) ^ W10)
+
+#define RND(A, B, C, D, E, F, G, H, TJ, Wi, Wj, FF, GG)           \
+     do {                                                         \
+       const SM3_WORD A12 = ROTATE(A, 12);                        \
+       const SM3_WORD A12_SM = A12 + E + TJ;                      \
+       const SM3_WORD SS1 = ROTATE(A12_SM, 7);                    \
+       const SM3_WORD TT1 = FF(A, B, C) + D + (SS1 ^ A12) + (Wj); \
+       const SM3_WORD TT2 = GG(E, F, G) + H + SS1 + Wi;           \
+       B = ROTATE(B, 9);                                          \
+       D = TT1;                                                   \
+       F = ROTATE(F, 19);                                         \
+       H = P0(TT2);                                               \
+     } while(0)
+
+#define R1(A,B,C,D,E,F,G,H,TJ,Wi,Wj) \
+   RND(A,B,C,D,E,F,G,H,TJ,Wi,Wj,FF0,GG0)
+
+#define R2(A,B,C,D,E,F,G,H,TJ,Wi,Wj) \
+   RND(A,B,C,D,E,F,G,H,TJ,Wi,Wj,FF1,GG1)
+
+#define SM3_A 0x7380166fUL
+#define SM3_B 0x4914b2b9UL
+#define SM3_C 0x172442d7UL
+#define SM3_D 0xda8a0600UL
+#define SM3_E 0xa96f30bcUL
+#define SM3_F 0x163138aaUL
+#define SM3_G 0xe38dee4dUL
+#define SM3_H 0xb0fb0e4eUL

--- a/src/regress/lib/libcrypto/Makefile
+++ b/src/regress/lib/libcrypto/Makefile
@@ -43,6 +43,7 @@ SUBDIR= \
 	sha2 \
 	sha256 \
 	sha512 \
+	sm3 \
 	utf8 \
 	wycheproof \
 	x509

--- a/src/regress/lib/libcrypto/sm3/sm3test.c
+++ b/src/regress/lib/libcrypto/sm3/sm3test.c
@@ -1,0 +1,84 @@
+/*
+* Copyright (c) 2018, Ribose Inc
+*
+* Permission to use, copy, modify, and/or distribute this software for any
+* purpose with or without fee is hereby granted, provided that the above
+* copyright notice and this permission notice appear in all copies.
+*
+* THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+* WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+* MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+* SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+* WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+* OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+* CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+
+#include <stdio.h>
+#include <string.h>
+#include <openssl/evp.h>
+
+#define SM3_TESTS 3
+
+const char* sm3_input[SM3_TESTS] = {
+   "",
+   "abc",
+   "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
+};
+
+const char* sm3_expected[SM3_TESTS] = {
+   "1AB21D8355CFA17F8E61194831E81A8F22BEC8C728FEFB747ED035EB5082AA2B",
+   "66C7F0F462EEEDD9D1F2D46BDC10E4E24167C4875CF2F7A2297DA02B8F4BA8E0",
+   "DEBE9FF92275B8A138604889C18E5A4D6FDB70E5387E5765293DCBA39C0C5732"
+};
+
+char* hex_encode(const uint8_t *input, size_t len)
+   {
+   const char* hex = "0123456789ABCDEF";
+   char   *out;
+   size_t  i;
+
+   out = malloc(len*2+1);
+   for (i=0; i<len; i++)
+      {
+      out[i*2]   = hex[input[i] >> 4];
+      out[i*2+1] = hex[input[i] & 0x0F];
+      }
+   out[len*2] = '\0';
+
+   return out;
+   }
+
+int main()
+   {
+   EVP_MD_CTX* ctx;
+   int i;
+   uint8_t digest[32];
+   char* hexdigest;
+   int err = 0;
+
+   ctx = EVP_MD_CTX_new();
+
+   for (i = 0; i != SM3_TESTS; ++i)
+      {
+      EVP_DigestInit(ctx, EVP_sm3());
+      EVP_DigestUpdate(ctx, sm3_input[i], strlen(sm3_input[i]));
+      EVP_DigestFinal(ctx, digest, NULL);
+
+      hexdigest = hex_encode(digest, sizeof(digest));
+
+      if (strcmp(hexdigest, sm3_expected[i]) != 0)
+         {
+         fprintf(stderr, "TEST %d failed\nProduced %s\nExpected %s\n", i, hexdigest, sm3_expected[i]);
+         ++err;
+         }
+      else
+         fprintf(stderr, "SM3 test %d ok\n", i);
+
+      free(hexdigest);
+      }
+
+   EVP_MD_CTX_free(ctx);
+
+   return (err > 0) ? 1 : 0;
+   }


### PR DESCRIPTION
This adds the SM3 hash function from the Chinese standard GB/T 32905-2016.

I have only tested it with the portable scaffold on Linux (PR upcoming for that).

If it is better I can send this as a patch to the mailing list but it seemed easier to get initial comments on GH.

CC @ronaldtse