### PR TITLE
Extend OAEP support

### DIFF
--- a/src/lib/libcrypto/rsa/rsa.h
+++ b/src/lib/libcrypto/rsa/rsa.h
@@ -230,6 +230,22 @@ struct rsa_st {
 		EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_RSA, EVP_PKEY_OP_TYPE_SIG,  \
 				EVP_PKEY_CTRL_GET_RSA_MGF1_MD, 0, (void *)pmd)
 
+#define EVP_PKEY_CTX_set_rsa_oaep_md(ctx, md) \
+	EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_RSA, EVP_PKEY_OP_TYPE_CRYPT, \
+			EVP_PKEY_CTRL_RSA_OAEP_MD, 0, (void *)(md))
+
+#define EVP_PKEY_CTX_get_rsa_oaep_md(ctx, pmd) \
+	EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_RSA, EVP_PKEY_OP_TYPE_CRYPT, \
+			EVP_PKEY_CTRL_GET_RSA_OAEP_MD, 0, (void *)(pmd))
+
+#define EVP_PKEY_CTX_set0_rsa_oaep_label(ctx, l, llen) \
+	EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_RSA, EVP_PKEY_OP_TYPE_CRYPT, \
+			EVP_PKEY_CTRL_RSA_OAEP_LABEL, llen, (void *)(l))
+
+#define EVP_PKEY_CTX_get0_rsa_oaep_label(ctx, l) \
+	EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_RSA, EVP_PKEY_OP_TYPE_CRYPT, \
+			EVP_PKEY_CTRL_GET_RSA_OAEP_LABEL, 0, (void *)(l))
+
 #define EVP_PKEY_CTRL_RSA_PADDING	(EVP_PKEY_ALG_CTRL + 1)
 #define EVP_PKEY_CTRL_RSA_PSS_SALTLEN	(EVP_PKEY_ALG_CTRL + 2)
 
@@ -240,6 +256,12 @@ struct rsa_st {
 #define EVP_PKEY_CTRL_GET_RSA_PADDING		(EVP_PKEY_ALG_CTRL + 6)
 #define EVP_PKEY_CTRL_GET_RSA_PSS_SALTLEN	(EVP_PKEY_ALG_CTRL + 7)
 #define EVP_PKEY_CTRL_GET_RSA_MGF1_MD		(EVP_PKEY_ALG_CTRL + 8)
+
+#define EVP_PKEY_CTRL_RSA_OAEP_MD		(EVP_PKEY_ALG_CTRL + 9)
+#define EVP_PKEY_CTRL_RSA_OAEP_LABEL		(EVP_PKEY_ALG_CTRL + 10)
+
+#define EVP_PKEY_CTRL_GET_RSA_OAEP_MD		(EVP_PKEY_ALG_CTRL + 11)
+#define EVP_PKEY_CTRL_GET_RSA_OAEP_LABEL	(EVP_PKEY_ALG_CTRL + 12)
 
 #define RSA_PKCS1_PADDING	1
 #define RSA_SSLV23_PADDING	2
@@ -368,6 +390,14 @@ int RSA_padding_add_PKCS1_OAEP(unsigned char *to, int tlen,
 int RSA_padding_check_PKCS1_OAEP(unsigned char *to, int tlen,
     const unsigned char *f, int fl, int rsa_len,
     const unsigned char *p, int pl);
+int RSA_padding_add_PKCS1_OAEP_mgf1(unsigned char *to, int tlen,
+    const unsigned char *from, int flen,
+    const unsigned char *param, int plen,
+    const EVP_MD *md, const EVP_MD *mgf1md);
+int RSA_padding_check_PKCS1_OAEP_mgf1(unsigned char *to, int tlen,
+    const unsigned char *from, int flen, int num,
+    const unsigned char *param, int plen,
+    const EVP_MD *md, const EVP_MD *mgf1md);
 int RSA_padding_add_none(unsigned char *to, int tlen,
     const unsigned char *f, int fl);
 int RSA_padding_check_none(unsigned char *to, int tlen,
@@ -574,6 +604,7 @@ void ERR_load_RSA_strings(void);
 #define RSA_R_D_E_NOT_CONGRUENT_TO_1			 123
 #define RSA_R_FIRST_OCTET_INVALID			 133
 #define RSA_R_ILLEGAL_OR_UNSUPPORTED_PADDING_MODE	 144
+#define RSA_R_INVALID_DIGEST				 157
 #define RSA_R_INVALID_DIGEST_LENGTH			 143
 #define RSA_R_INVALID_HEADER				 137
 #define RSA_R_INVALID_KEYBITS				 145

--- a/src/lib/libcrypto/rsa/rsa_err.c
+++ b/src/lib/libcrypto/rsa/rsa_err.c
@@ -96,6 +96,7 @@ static ERR_STRING_DATA RSA_str_reasons[] = {
 	{ERR_REASON(RSA_R_D_E_NOT_CONGRUENT_TO_1), "d e not congruent to 1"},
 	{ERR_REASON(RSA_R_FIRST_OCTET_INVALID)   , "first octet invalid"},
 	{ERR_REASON(RSA_R_ILLEGAL_OR_UNSUPPORTED_PADDING_MODE), "illegal or unsupported padding mode"},
+	{ERR_REASON(RSA_R_INVALID_DIGEST)        , "invalid digest"},
 	{ERR_REASON(RSA_R_INVALID_DIGEST_LENGTH) , "invalid digest length"},
 	{ERR_REASON(RSA_R_INVALID_HEADER)        , "invalid header"},
 	{ERR_REASON(RSA_R_INVALID_KEYBITS)       , "invalid keybits"},


### PR DESCRIPTION
Provide methods: EVP_PKEY_CTX_{g,s}et_rsa_oaep_md,
EVP_PKEY_CTX_{g,s}et0_rsa_oaep_label.

Based on Stephen Henson's patches for OpenSSL 1.1.0:
https://github.com/openssl/openssl/commit/271fef0ef39a1c0cb5233a5adf3ff8733abb375e
https://github.com/openssl/openssl/commit/211a14f6279f127f7a5a59948819bd939131b0b6