### PR TITLE
Fix compilation for gcc 4.4.7

### DIFF
--- a/src/lib/libcrypto/rsa/rsa.h
+++ b/src/lib/libcrypto/rsa/rsa.h
@@ -345,7 +345,7 @@ RSA *d2i_RSAPrivateKey(RSA **a, const unsigned char **in, long len);
 int i2d_RSAPrivateKey(const RSA *a, unsigned char **out);
 extern const ASN1_ITEM RSAPrivateKey_it;
 
-typedef struct rsa_pss_params_st {
+struct rsa_pss_params_st {
 	X509_ALGOR *hashAlgorithm;
 	X509_ALGOR *maskGenAlgorithm;
 	ASN1_INTEGER *saltLength;
@@ -353,7 +353,7 @@ typedef struct rsa_pss_params_st {
 
 	/* Hash algorithm decoded from maskGenAlgorithm. */
 	X509_ALGOR *maskHash;
-} RSA_PSS_PARAMS;
+};
 
 RSA_PSS_PARAMS *RSA_PSS_PARAMS_new(void);
 void RSA_PSS_PARAMS_free(RSA_PSS_PARAMS *a);


### PR DESCRIPTION
I've encountered this when cross-compiling for embedded MIPS system using older toolchain. 
Without this patch i get 
```
Making all in crypto
make[1]: Entering directory '/opt/mips/libressl/crypto'
make  all-am
make[2]: Entering directory '/opt/mips/libressl/crypto'
  CC       asn1/libcrypto_la-a_digest.lo
In file included from ../include/openssl/x509.h:96,
                 from asn1/a_digest.c:67:
../include/openssl/rsa.h:356: error: redefinition of typedef 'RSA_PSS_PARAMS'
../include/openssl/rsa.h:87: note: previous declaration of 'RSA_PSS_PARAMS' was here
Makefile:4865: recipe for target 'asn1/libcrypto_la-a_digest.lo' failed
make[2]: *** [asn1/libcrypto_la-a_digest.lo] Error 1
make[2]: Leaving directory '/opt/mips/libressl/crypto'
Makefile:1488: recipe for target 'all' failed
make[1]: *** [all] Error 2
```