### PR TITLE
s_client: fix use of possibly uninitialized values

### DIFF
--- a/src/usr.bin/openssl/s_client.c
+++ b/src/usr.bin/openssl/s_client.c
@@ -293,7 +293,7 @@ s_client_main(int argc, char **argv)
 {
 	unsigned int off = 0, clr = 0;
 	SSL *con = NULL;
-	int s, k, p, pending, state = 0, af = AF_UNSPEC;
+	int s, k, p = 0, pending = 0, state = 0, af = AF_UNSPEC;
 	char *cbuf = NULL, *sbuf = NULL, *mbuf = NULL, *pbuf = NULL;
 	int cbuf_len, cbuf_off;
 	int sbuf_len, sbuf_off;


### PR DESCRIPTION
Fixes the following compile errors when building with '-Werror=maybe-uninitialized':

    s_client.c:1172:7: error: ‘pending’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
           BIO_printf(bio_err,
           ^~~~~~~~~~~~~~~~~~~
               "peek of %d different from read of %d!\n",
               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
               p, k);
               ~~~~~
    s_client.c:1160:7: error: ‘p’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
           BIO_printf(bio_err,
           ^~~~~~~~~~~~~~~~~~~
               "peeked %d but pending %d!\n", p, pending);
               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Fixes https://github.com/libressl-portable/portable/issues/577.