### PR TITLE
libcrypto: Add CBC, CFB64 and OFB64 test coverage for RC2

### DIFF
--- a/src/regress/lib/libcrypto/rc2/rc2_test.c
+++ b/src/regress/lib/libcrypto/rc2/rc2_test.c
@@ -26,9 +26,13 @@ struct rc2_test {
 	const uint8_t key[64];
 	const int key_len;
 	const int key_bits;
-	const int len;
-	const uint8_t in[8];
-	const uint8_t out[8];
+	const uint8_t iv[64];
+	const int iv_len;
+	const uint8_t in[64];
+	const int in_len;
+	const uint8_t out[64];
+	const int out_len;
+	const int padding;
 };
 
 static const struct rc2_test rc2_tests[] = {
@@ -40,13 +44,14 @@ static const struct rc2_test rc2_tests[] = {
 		},
 		.key_len = 8,
 		.key_bits = 63,
-		.len = 8,
 		.in = {
 			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 		},
+		.in_len = 8,
 		.out = {
 			0xeb, 0xb7, 0x73, 0xf9, 0x93, 0x27, 0x8e, 0xff,
 		},
+		.out_len = 8,
 	},
 	{
 		.mode = NID_rc2_ecb,
@@ -55,13 +60,14 @@ static const struct rc2_test rc2_tests[] = {
 		},
 		.key_len = 8,
 		.key_bits = 64,
-		.len = 8,
 		.in = {
 			0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
 		},
+		.in_len = 8,
 		.out = {
 			0x27, 0x8b, 0x27, 0xe4, 0x2e, 0x2f, 0x0d, 0x49,
 		},
+		.out_len = 8,
 	},
 	{
 		.mode = NID_rc2_ecb,
@@ -70,13 +76,14 @@ static const struct rc2_test rc2_tests[] = {
 		},
 		.key_len = 8,
 		.key_bits = 64,
-		.len = 8,
 		.in = {
 			0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
 		},
+		.in_len = 8,
 		.out = {
 			0x30, 0x64, 0x9e, 0xdf, 0x9b, 0xe7, 0xd2, 0xc2,
 		},
+		.out_len = 8,
 	},
 	{
 		.mode = NID_rc2_ecb,
@@ -85,13 +92,14 @@ static const struct rc2_test rc2_tests[] = {
 		},
 		.key_len = 1,
 		.key_bits = 64,
-		.len = 8,
 		.in = {
 			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 		},
+		.in_len = 8,
 		.out = {
 			0x61, 0xa8, 0xa2, 0x44, 0xad, 0xac, 0xcc, 0xf0,
 		},
+		.out_len = 8,
 	},
 	{
 		.mode = NID_rc2_ecb,
@@ -100,13 +108,14 @@ static const struct rc2_test rc2_tests[] = {
 		},
 		.key_len = 7,
 		.key_bits = 64,
-		.len = 8,
 		.in = {
 			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 		},
+		.in_len = 8,
 		.out = {
 			0x6c, 0xcf, 0x43, 0x08, 0x97, 0x4c, 0x26, 0x7f,
 		},
+		.out_len = 8,
 	},
 	{
 		.mode = NID_rc2_ecb,
@@ -116,13 +125,14 @@ static const struct rc2_test rc2_tests[] = {
 		},
 		.key_len = 16,
 		.key_bits = 64,
-		.len = 8,
 		.in = {
 			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 		},
+		.in_len = 8,
 		.out = {
 			0x1a, 0x80, 0x7d, 0x27, 0x2b, 0xbe, 0x5d, 0xb1,
 		},
+		.out_len = 8,
 	},
 	{
 		.mode = NID_rc2_ecb,
@@ -132,13 +142,14 @@ static const struct rc2_test rc2_tests[] = {
 		},
 		.key_len = 16,
 		.key_bits = 128,
-		.len = 8,
 		.in = {
 			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 		},
+		.in_len = 8,
 		.out = {
 			0x22, 0x69, 0x55, 0x2a, 0xb0, 0xf8, 0x5c, 0xa6,
 		},
+		.out_len = 8,
 	},
 	{
 		.mode = NID_rc2_ecb,
@@ -151,13 +162,14 @@ static const struct rc2_test rc2_tests[] = {
 		},
 		.key_len = 33,
 		.key_bits = 129,
-		.len = 8,
 		.in = {
 			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 		},
+		.in_len = 8,
 		.out = {
 			0x5b, 0x78, 0xd3, 0xa4, 0x3d, 0xff, 0xf1, 0xf1,
 		},
+		.out_len = 8,
 	},
 
 	/* ECB (Test vectors from http://websites.umich.edu/~x509/ssleay/rrc2.html) */
@@ -169,13 +181,14 @@ static const struct rc2_test rc2_tests[] = {
 		},
 		.key_len = 16,
 		.key_bits = 1024,
-		.len = 8,
 		.in = {
 			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 		},
+		.in_len = 8,
 		.out = {
 			0x1c, 0x19, 0x8a, 0x83, 0x8d, 0xf0, 0x28, 0xb7,
 		},
+		.out_len = 8,
 	},
 	{
 		.mode = NID_rc2_ecb,
@@ -185,13 +198,14 @@ static const struct rc2_test rc2_tests[] = {
 		},
 		.key_len = 16,
 		.key_bits = 1024,
-		.len = 8,
 		.in = {
 			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 		},
+		.in_len = 8,
 		.out = {
 			0x21, 0x82, 0x9C, 0x78, 0xA9, 0xF9, 0xC0, 0x74,
 		},
+		.out_len = 8,
 	},
 	{
 		.mode = NID_rc2_ecb,
@@ -201,13 +215,14 @@ static const struct rc2_test rc2_tests[] = {
 		},
 		.key_len = 16,
 		.key_bits = 1024,
-		.len = 8,
 		.in = {
 			0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
 		},
+		.in_len = 8,
 		.out = {
 			0x13, 0xdb, 0x35, 0x17, 0xd3, 0x21, 0x86, 0x9e,
 		},
+		.out_len = 8,
 	},
 	{
 		.mode = NID_rc2_ecb,
@@ -217,13 +232,305 @@ static const struct rc2_test rc2_tests[] = {
 		},
 		.key_len = 16,
 		.key_bits = 1024,
-		.len = 8,
 		.in = {
 			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 		},
+		.in_len = 8,
 		.out = {
 			0x50, 0xdc, 0x01, 0x62, 0xbd, 0x75, 0x7f, 0x31,
 		},
+		.out_len = 8,
+	},
+
+	/* CBC (generated using https://github.com/joshuasing/libressl-test-gen) */
+	{
+		.mode = NID_rc2_cbc,
+		.key = {
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		},
+		.key_len = 8,
+		.key_bits = 64,
+		.iv = {
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		},
+		.iv_len = 8,
+		.in = {
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		},
+		.in_len = 16,
+		.out = {
+			0xeb, 0xb7, 0x73, 0xf9, 0x93, 0x27, 0x8e, 0xff,
+			0xf0, 0x51, 0x77, 0x8b, 0x65, 0xdb, 0x13, 0x57,
+		},
+		.out_len = 16,
+	},
+	{
+		.mode = NID_rc2_cbc,
+		.key = {
+			0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+			0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+		},
+		.key_len = 16,
+		.key_bits = 128,
+		.iv = {
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		},
+		.iv_len = 8,
+		.in = {
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		},
+		.in_len = 16,
+		.out = {
+			0x9c, 0x4b, 0xfe, 0x6d, 0xfe, 0x73, 0x9c, 0x2b,
+			0x52, 0x8f, 0xc8, 0x47, 0x2b, 0x66, 0xf9, 0x70,
+		},
+		.out_len = 16,
+	},
+	{
+		.mode = NID_rc2_cbc,
+		.key = {
+			0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+			0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+		},
+		.key_len = 16,
+		.key_bits = 128,
+		.iv = {
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		},
+		.iv_len = 8,
+		.in = {
+			0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+			0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+		},
+		.in_len = 16,
+		.out = {
+			0x8b, 0x11, 0x08, 0x1c, 0xf0, 0xa0, 0x86, 0xe9,
+			0x60, 0x57, 0x69, 0x5d, 0xdd, 0x42, 0x38, 0xe3,
+		},
+		.out_len = 16,
+	},
+	{
+		.mode = NID_rc2_cbc,
+		.key = {
+			0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+			0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+		},
+		.key_len = 16,
+		.key_bits = 128,
+		.iv = {
+			0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+		},
+		.iv_len = 8,
+		.in = {
+			0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+			0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+			0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
+			0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
+		},
+		.in_len = 32,
+		.out = {
+			0x9c, 0x4b, 0xfe, 0x6d, 0xfe, 0x73, 0x9c, 0x2b,
+			0x29, 0xf1, 0x7a, 0xd2, 0x16, 0xa0, 0xb2, 0xc6,
+			0xd1, 0xa2, 0x31, 0xbe, 0xa3, 0x94, 0xc6, 0xb0,
+			0x81, 0x22, 0x27, 0x17, 0x5b, 0xd4, 0x6d, 0x29,
+		},
+		.out_len = 32,
+	},
+
+	/* CFB64 (generated using https://github.com/joshuasing/libressl-test-gen) */
+	{
+		.mode = NID_rc2_cfb64,
+		.key = {
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		},
+		.key_len = 8,
+		.key_bits = 64,
+		.iv = {
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		},
+		.iv_len = 8,
+		.in = {
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		},
+		.in_len = 16,
+		.out = {
+			0xeb, 0xb7, 0x73, 0xf9, 0x93, 0x27, 0x8e, 0xff,
+			0xf0, 0x51, 0x77, 0x8b, 0x65, 0xdb, 0x13, 0x57,
+		},
+		.out_len = 16,
+	},
+	{
+		.mode = NID_rc2_cfb64,
+		.key = {
+			0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+			0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+		},
+		.key_len = 16,
+		.key_bits = 128,
+		.iv = {
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		},
+		.iv_len = 8,
+		.in = {
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		},
+		.in_len = 16,
+		.out = {
+			0x9c, 0x4b, 0xfe, 0x6d, 0xfe, 0x73, 0x9c, 0x2b,
+			0x52, 0x8f, 0xc8, 0x47, 0x2b, 0x66, 0xf9, 0x70,
+		},
+		.out_len = 16,
+	},
+	{
+		.mode = NID_rc2_cfb64,
+		.key = {
+			0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+			0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+		},
+		.key_len = 16,
+		.key_bits = 128,
+		.iv = {
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		},
+		.iv_len = 8,
+		.in = {
+			0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+			0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+		},
+		.in_len = 16,
+		.out = {
+			0x9c, 0x4a, 0xfc, 0x6e, 0xfa, 0x76, 0x9a, 0x2c,
+			0xeb, 0xdf, 0x25, 0xb0, 0x15, 0x8b, 0x6a, 0x2a,
+		},
+		.out_len = 16,
+	},
+	{
+		.mode = NID_rc2_cfb64,
+		.key = {
+			0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+			0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+		},
+		.key_len = 16,
+		.key_bits = 128,
+		.iv = {
+			0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+		},
+		.iv_len = 8,
+		.in = {
+			0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+			0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+			0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
+			0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
+		},
+		.in_len = 32,
+		.out = {
+			0x8b, 0x10, 0x0a, 0x1f, 0xf4, 0xa5, 0x80, 0xee,
+			0x94, 0x4d, 0xc3, 0xcd, 0x26, 0x79, 0x81, 0xc0,
+			0xe9, 0x3e, 0x20, 0x85, 0x11, 0x71, 0x61, 0x2a,
+			0x1d, 0x4c, 0x8a, 0xe2, 0xb7, 0x0a, 0xa8, 0xcf,
+		},
+		.out_len = 32,
+	},
+
+	/* OFB64 (generated using https://github.com/joshuasing/libressl-test-gen) */
+	{
+		.mode = NID_rc2_ofb64,
+		.key = {
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		},
+		.key_len = 8,
+		.key_bits = 64,
+		.iv = {
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		},
+		.iv_len = 8,
+		.in = {
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		},
+		.in_len = 16,
+		.out = {
+			0xeb, 0xb7, 0x73, 0xf9, 0x93, 0x27, 0x8e, 0xff,
+			0xf0, 0x51, 0x77, 0x8b, 0x65, 0xdb, 0x13, 0x57,
+		},
+		.out_len = 16,
+	},
+	{
+		.mode = NID_rc2_ofb64,
+		.key = {
+			0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+			0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+		},
+		.key_len = 16,
+		.key_bits = 128,
+		.iv = {
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		},
+		.iv_len = 8,
+		.in = {
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		},
+		.in_len = 16,
+		.out = {
+			0x9c, 0x4b, 0xfe, 0x6d, 0xfe, 0x73, 0x9c, 0x2b,
+			0x52, 0x8f, 0xc8, 0x47, 0x2b, 0x66, 0xf9, 0x70,
+		},
+		.out_len = 16,
+	},
+	{
+		.mode = NID_rc2_ofb64,
+		.key = {
+			0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+			0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+		},
+		.key_len = 16,
+		.key_bits = 128,
+		.iv = {
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		},
+		.iv_len = 8,
+		.in = {
+			0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+			0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+		},
+		.in_len = 16,
+		.out = {
+			0x9c, 0x4a, 0xfc, 0x6e, 0xfa, 0x76, 0x9a, 0x2c,
+			0x5a, 0x86, 0xc2, 0x4c, 0x27, 0x6b, 0xf7, 0x7f,
+		},
+		.out_len = 16,
+	},
+	{
+		.mode = NID_rc2_ofb64,
+		.key = {
+			0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+			0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+		},
+		.key_len = 16,
+		.key_bits = 128,
+		.iv = {
+			0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+		},
+		.iv_len = 8,
+		.in = {
+			0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+			0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+			0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
+			0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
+		},
+		.in_len = 32,
+		.out = {
+			0x8b, 0x10, 0x0a, 0x1f, 0xf4, 0xa5, 0x80, 0xee,
+			0xfa, 0x1d, 0x1a, 0x7c, 0xb2, 0x93, 0x00, 0x9d,
+			0x36, 0xa1, 0xff, 0x3a, 0x77, 0x1d, 0x00, 0x9b,
+			0x20, 0xde, 0x5f, 0x93, 0xcc, 0x3e, 0x51, 0xaa,
+		},
+		.out_len = 32,
 	},
 };
 
@@ -240,7 +547,7 @@ rc2_ecb_test(size_t test_number, const struct rc2_test *rt)
 	RC2_set_key(&key, rt->key_len, rt->key, rt->key_bits);
 	RC2_ecb_encrypt(rt->in, out, &key, 1);
 
-	if (memcmp(rt->out, out, rt->len) != 0) {
+	if (memcmp(rt->out, out, rt->out_len) != 0) {
 		fprintf(stderr, "FAIL (%s:%zu): encryption mismatch\n",
 		    SN_rc2_ecb, test_number);
 		return 0;
@@ -251,7 +558,7 @@ rc2_ecb_test(size_t test_number, const struct rc2_test *rt)
 	RC2_set_key(&key, rt->key_len, rt->key, rt->key_bits);
 	RC2_ecb_encrypt(rt->out, out, &key, 0);
 
-	if (memcmp(rt->in, out, rt->len) != 0) {
+	if (memcmp(rt->in, out, rt->in_len) != 0) {
 		fprintf(stderr, "FAIL (%s:%zu): decryption mismatch\n",
 		    SN_rc2_ecb, test_number);
 		return 0;
@@ -261,7 +568,112 @@ rc2_ecb_test(size_t test_number, const struct rc2_test *rt)
 }
 
 static int
-rc2_evp_test(size_t test_number, const struct rc2_test *rt, const char *label, const EVP_CIPHER *cipher)
+rc2_cbc_test(size_t test_number, const struct rc2_test *rt)
+{
+	RC2_KEY key;
+	uint8_t out[512];
+	uint8_t iv[64];
+
+	/* Encryption */
+	memset(out, 0, sizeof(out));
+	memcpy(iv, rt->iv, rt->iv_len);
+	RC2_set_key(&key, rt->key_len, rt->key, rt->key_bits);
+	RC2_cbc_encrypt(rt->in, out, rt->in_len, &key, iv, 1);
+
+	if (memcmp(rt->out, out, rt->out_len) != 0) {
+		fprintf(stderr, "FAIL (%s:%zu): encryption mismatch\n",
+		    SN_rc2_cbc, test_number);
+		return 0;
+	}
+
+	/* Decryption */
+	memset(out, 0, sizeof(out));
+	memcpy(iv, rt->iv, rt->iv_len);
+	RC2_set_key(&key, rt->key_len, rt->key, rt->key_bits);
+	RC2_cbc_encrypt(rt->out, out, rt->out_len, &key, iv, 0);
+
+	if (memcmp(rt->in, out, rt->in_len) != 0) {
+		fprintf(stderr, "FAIL (%s:%zu): decryption mismatch\n",
+		    SN_rc2_cbc, test_number);
+		return 0;
+	}
+
+	return 1;
+}
+
+static int
+rc2_cfb64_test(size_t test_number, const struct rc2_test *rt)
+{
+	RC2_KEY key;
+	uint8_t out[512];
+	uint8_t iv[64];
+	int remainder = 0;
+
+	/* Encryption */
+	memset(out, 0, sizeof(out));
+	memcpy(iv, rt->iv, rt->iv_len);
+	RC2_set_key(&key, rt->key_len, rt->key, rt->key_bits);
+	RC2_cfb64_encrypt(rt->in, out, rt->in_len * 8, &key, iv, &remainder, 1);
+
+	if (memcmp(rt->out, out, rt->out_len) != 0) {
+		fprintf(stderr, "FAIL (%s:%zu): encryption mismatch\n",
+		    SN_rc2_cbc, test_number);
+		return 0;
+	}
+
+	/* Decryption */
+	memset(out, 0, sizeof(out));
+	memcpy(iv, rt->iv, rt->iv_len);
+	RC2_set_key(&key, rt->key_len, rt->key, rt->key_bits);
+	RC2_cfb64_encrypt(rt->out, out, rt->out_len, &key, iv, &remainder, 0);
+
+	if (memcmp(rt->in, out, rt->in_len) != 0) {
+		fprintf(stderr, "FAIL (%s:%zu): decryption mismatch\n",
+		    SN_rc2_cbc, test_number);
+		return 0;
+	}
+
+	return 1;
+}
+
+static int
+rc2_ofb64_test(size_t test_number, const struct rc2_test *rt)
+{
+	RC2_KEY key;
+	uint8_t out[512];
+	uint8_t iv[64];
+	int remainder = 0;
+
+	/* Encryption */
+	memset(out, 0, sizeof(out));
+	memcpy(iv, rt->iv, rt->iv_len);
+	RC2_set_key(&key, rt->key_len, rt->key, rt->key_bits);
+	RC2_ofb64_encrypt(rt->in, out, rt->in_len, &key, iv, &remainder);
+
+	if (memcmp(rt->out, out, rt->out_len) != 0) {
+		fprintf(stderr, "FAIL (%s:%zu): encryption mismatch\n",
+		    SN_rc2_cbc, test_number);
+		return 0;
+	}
+
+	/* Decryption */
+	memset(out, 0, sizeof(out));
+	memcpy(iv, rt->iv, rt->iv_len);
+	RC2_set_key(&key, rt->key_len, rt->key, rt->key_bits);
+	RC2_ofb64_encrypt(rt->out, out, rt->out_len, &key, iv, &remainder);
+
+	if (memcmp(rt->in, out, rt->in_len) != 0) {
+		fprintf(stderr, "FAIL (%s:%zu): decryption mismatch\n",
+		     SN_rc2_cbc, test_number);
+		return 0;
+	}
+
+	return 1;
+}
+
+static int
+rc2_evp_test(size_t test_number, const struct rc2_test *rt, const char *label,
+    const EVP_CIPHER *cipher)
 {
 	EVP_CIPHER_CTX *ctx;
 	uint8_t out[512];
@@ -298,23 +710,23 @@ rc2_evp_test(size_t test_number, const struct rc2_test *rt, const char *label, c
 		goto failed;
 	}
 
-	if (!EVP_CIPHER_CTX_set_padding(ctx, 0)) {
+	if (!EVP_CIPHER_CTX_set_padding(ctx, rt->padding)) {
 		fprintf(stderr,
 		    "FAIL (%s:%zu): EVP_CIPHER_CTX_set_padding failed\n",
 		    label, test_number);
 		goto failed;
 	}
 
-	if (!EVP_EncryptInit(ctx, NULL, rt->key, NULL)) {
+	if (!EVP_EncryptInit(ctx, NULL, rt->key, rt->iv)) {
 		fprintf(stderr, "FAIL (%s:%zu): EVP_EncryptInit failed\n",
 		    label, test_number);
 		goto failed;
 	}
 
-	for (i = 0; i < rt->len;) {
-		in_len = arc4random_uniform(sizeof(rt->len / 2));
-		if (in_len > rt->len - i)
-			in_len = rt->len - i;
+	for (i = 0; i < rt->in_len;) {
+		in_len = arc4random_uniform(sizeof(rt->in_len) / 2);
+		if (in_len > rt->in_len - i)
+			in_len = rt->in_len - i;
 
 		if (!EVP_EncryptUpdate(ctx, out + total_len, &out_len,
 			rt->in + i, in_len)) {
@@ -342,14 +754,14 @@ rc2_evp_test(size_t test_number, const struct rc2_test *rt, const char *label, c
 		goto failed;
 	}
 
-	if (total_len != rt->len) {
+	if (total_len != rt->out_len) {
 		fprintf(stderr,
 		    "FAIL (%s:%zu): EVP encryption length mismatch\n",
 		    label, test_number);
 		goto failed;
 	}
 
-	if (memcmp(rt->out, out, rt->len) != 0) {
+	if (memcmp(rt->out, out, rt->out_len) != 0) {
 		fprintf(stderr, "FAIL (%s:%zu): EVP encryption mismatch\n",
 		    label, test_number);
 		goto failed;
@@ -378,23 +790,23 @@ rc2_evp_test(size_t test_number, const struct rc2_test *rt, const char *label, c
 		goto failed;
 	}
 
-	if (!EVP_CIPHER_CTX_set_padding(ctx, 0)) {
+	if (!EVP_CIPHER_CTX_set_padding(ctx, rt->padding)) {
 		fprintf(stderr,
 		    "FAIL (%s:%zu): EVP_CIPHER_CTX_set_padding failed\n",
 		    label, test_number);
 		goto failed;
 	}
 
-	if (!EVP_DecryptInit(ctx, NULL, rt->key, NULL)) {
+	if (!EVP_DecryptInit(ctx, NULL, rt->key, rt->iv)) {
 		fprintf(stderr, "FAIL (%s:%zu): EVP_DecryptInit failed\n",
 		    label, test_number);
 		goto failed;
 	}
 
-	for (i = 0; i < rt->len;) {
-		in_len = arc4random_uniform(sizeof(rt->len / 2));
-		if (in_len > rt->len - i)
-			in_len = rt->len - i;
+	for (i = 0; i < rt->out_len;) {
+		in_len = arc4random_uniform(sizeof(rt->out_len) / 2);
+		if (in_len > rt->out_len - i)
+			in_len = rt->out_len - i;
 
 		if (!EVP_DecryptUpdate(ctx, out + total_len, &out_len,
 			rt->out + i, in_len)) {
@@ -422,14 +834,14 @@ rc2_evp_test(size_t test_number, const struct rc2_test *rt, const char *label, c
 		goto failed;
 	}
 
-	if (total_len != rt->len) {
+	if (total_len != rt->in_len) {
 		fprintf(stderr,
 		    "FAIL (%s:%zu): EVP decryption length mismatch\n",
 		    label, test_number);
 		goto failed;
 	}
 
-	if (memcmp(rt->in, out, rt->len) != 0) {
+	if (memcmp(rt->in, out, rt->in_len) != 0) {
 		fprintf(stderr, "FAIL (%s:%zu): EVP decryption mismatch\n",
 		    label, test_number);
 		goto failed;
@@ -458,6 +870,24 @@ rc2_test(void)
 			label = SN_rc2_ecb;
 			cipher = EVP_rc2_ecb();
 			if (!rc2_ecb_test(i, rt))
+				goto failed;
+			break;
+		case NID_rc2_cbc:
+			label = SN_rc2_cbc;
+			cipher = EVP_rc2_cbc();
+			if (!rc2_cbc_test(i, rt))
+				goto failed;
+			break;
+		case NID_rc2_cfb64:
+			label = SN_rc2_cfb64;
+			cipher = EVP_rc2_cfb64();
+			if (!rc2_cfb64_test(i, rt))
+				goto failed;
+			break;
+		case NID_rc2_ofb64:
+			label = SN_rc2_ofb64;
+			cipher = EVP_rc2_ofb();
+			if (!rc2_ofb64_test(i, rt))
 				goto failed;
 			break;
 		default:


### PR DESCRIPTION
I have added CBC, CFB64 and OFB64 test coverage for RC2 as a follow up for #138  